### PR TITLE
Implement Artisan commands for employee management and backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@
 Homestead.json
 Homestead.yaml
 Thumbs.db
+# Logs
+/storage/logs/*.log
+
+# Backups
+/storage/backups/*.sql
+/storage/backups/*.json

--- a/app/Console/Commands/DeleteOldEmployeeLogs.php
+++ b/app/Console/Commands/DeleteOldEmployeeLogs.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Log;
+
+class DeleteOldEmployeeLogs extends Command
+{
+    protected $signature = 'employee-logs:cleanup';
+    protected $description = 'Delete employee logs older than one month';
+
+    private const MODEL = 'App\Models\Employee';
+
+    public function handle(): int
+    {
+        $deleted = Log::where('model', self::MODEL)
+            ->where('created_at', '<', now()->subMonth())
+            ->delete();
+
+        $this->info("Deleted {$deleted} old employee logs.");
+
+            return Command::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ExportDatabase.php
+++ b/app/Console/Commands/ExportDatabase.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Ifsnop\Mysqldump\Mysqldump;
+use Carbon\Carbon;
+
+class ExportDatabase extends Command
+{
+    protected $signature = 'db:export';
+    protected $description = 'Export the entire database to a SQL file';
+
+    public function handle(): int
+    {
+        try {
+            $fileName = 'backup_' . Carbon::now()->format('Y_m_d_His') . '.sql';
+            $filePath = storage_path("backups/{$fileName}");
+
+            // Ensure directory exists
+            if (!is_dir(dirname($filePath))) {
+                mkdir(dirname($filePath), 0755, true);
+                $this->info('Created backup directory.');
+            }
+
+            $connection = config('database.connections.mysql');
+
+            $this->info('Exporting database...');
+
+            $dump = new Mysqldump(
+                "mysql:host={$connection['host']};dbname={$connection['database']}",
+                $connection['username'],
+                $connection['password']
+            );
+            $dump->start($filePath);
+
+            $this->info("Database export completed successfully!");
+            $this->info("File saved at: {$filePath}");
+
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $this->error("Export failed: " . $e->getMessage());
+            return Command::FAILURE;
+        }
+    }
+}

--- a/app/Console/Commands/ExportEmployeesToJson.php
+++ b/app/Console/Commands/ExportEmployeesToJson.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Repositories\EmployeeRepository;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\File;
+
+class ExportEmployeesToJson extends Command
+{
+    protected $signature = 'employees:export-json';
+    protected $description = 'Export all employee data to a JSON file';
+
+    public function __construct(private EmployeeRepository $repository)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+
+        try {
+            $filePath = $this->getFilePath();
+
+            $employees = $this->repository->all();
+
+            if ($employees->isEmpty()) {
+                $this->warn('No employees found to export.');
+            }
+
+            File::put($filePath, $employees->toJson(JSON_PRETTY_PRINT));
+
+            $this->info("Employee export completed successfully!");
+            $this->info("File saved at: {$filePath}");
+
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $this->error("Export failed: " . $e->getMessage());
+            return Command::SUCCESS;
+        }
+    }
+
+    private function getFilePath(): string
+    {
+        $dir = storage_path('backups');
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+            $this->info('Created backups directory.');
+        }
+
+        return $dir . '/employees_' . Carbon::now()->format('Y_m_d_His') . '.json';
+    }
+}

--- a/app/Console/Commands/RemoveAllLogFiles.php
+++ b/app/Console/Commands/RemoveAllLogFiles.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class RemoveAllLogFiles extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'logs:remove-all';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Remove all log files from storage/logs directory';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $logPath = storage_path('logs');
+        $files = File::files($logPath);
+
+        collect($files)->each(fn($file) => File::delete($file));
+
+        $this->info($files ? 'All log files have been removed successfully.' : 'No log files found.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Repositories/EmployeeRepository.php
+++ b/app/Repositories/EmployeeRepository.php
@@ -8,7 +8,7 @@ class EmployeeRepository
 {
     public function all()
     {
-        return Employee::all();
+        return Employee::get();
     }
 
     public function find(int $id): ?Employee

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "ifsnop/mysqldump-php": "^2.12",
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3c16cb86c42230c6c023d9a5d9bcf42",
+    "content-hash": "cd5513104506a600e5ab83007a0e285d",
     "packages": [
         {
             "name": "brick/math",
@@ -1052,6 +1052,65 @@
                 }
             ],
             "time": "2025-08-22T14:27:06+00:00"
+        },
+        {
+            "name": "ifsnop/mysqldump-php",
+            "version": "v2.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ifsnop/mysqldump-php.git",
+                "reference": "2d3a43fc0c49f23bf7dee392b0dd1f8c799f89d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ifsnop/mysqldump-php/zipball/2d3a43fc0c49f23bf7dee392b0dd1f8c799f89d3",
+                "reference": "2d3a43fc0c49f23bf7dee392b0dd1f8c799f89d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.8.36",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ifsnop\\": "src/Ifsnop/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Diego Torres",
+                    "homepage": "https://github.com/ifsnop",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP version of mysqldump cli that comes with MySQL",
+            "homepage": "https://github.com/ifsnop/mysqldump-php",
+            "keywords": [
+                "PHP7",
+                "database",
+                "hhvm",
+                "mariadb",
+                "mysql",
+                "mysql-backup",
+                "mysqldump",
+                "pdo",
+                "php",
+                "php5",
+                "sql"
+            ],
+            "support": {
+                "issues": "https://github.com/ifsnop/mysqldump-php/issues",
+                "source": "https://github.com/ifsnop/mysqldump-php/tree/v2.12"
+            },
+            "time": "2023-04-12T07:43:14+00:00"
         },
         {
             "name": "laravel/framework",


### PR DESCRIPTION
## Summary
Added multiple Artisan commands to improve employee management, logging, and data export.

## Changes
- `employee-logs:cleanup` → Deletes employee logs older than one month
- `logs:remove-all` → Removes all log files from storage/logs
- `db:export` → Exports the entire database to a SQL file
- `employees:export-json` → Exports all employee data to a JSON file